### PR TITLE
docs: add mandatory TDD enforcement rules to specs

### DIFF
--- a/specs/001-ar-furniture-previewer/plan.md
+++ b/specs/001-ar-furniture-previewer/plan.md
@@ -37,6 +37,46 @@ AR Furniture Previewer is a cross-platform mobile application (iOS & Android) th
 
 **Gate Result**: ✅ PASS - No violations. Proceeding to Phase 0.
 
+---
+
+## ⚠️ TDD Enforcement (MANDATORY)
+
+**Test-Driven Development is NON-NEGOTIABLE for this project.**
+
+### TDD Workflow (Red-Green-Refactor)
+
+Every implementation task MUST follow this cycle:
+
+1. **🔴 RED**: Write a failing test that defines the expected behavior
+2. **🟢 GREEN**: Write the minimum code to make the test pass
+3. **🔵 REFACTOR**: Improve code quality while keeping tests green
+
+### Enforcement Rules
+
+| Rule | Description | Consequence of Violation |
+|------|-------------|-------------------------|
+| **Tests First** | No implementation PR can be merged without corresponding tests | PR will be rejected |
+| **Coverage Gate** | PRs must maintain ≥80% coverage for business logic | CI will fail |
+| **Critical Paths** | 100% coverage required for: stores, services, WebView bridge | Manual review required |
+| **Test Before Code** | Test file must be created BEFORE implementation file | PR review will check git history |
+
+### PR Checklist (Required)
+
+Every implementation PR MUST include:
+
+- [ ] Test file(s) created before implementation
+- [ ] All tests passing (`yarn test`)
+- [ ] Coverage meets threshold (`yarn test --coverage`)
+- [ ] Test file git commit predates implementation commit (for new features)
+
+### Exemptions
+
+**None.** There are no exceptions to TDD for this project.
+
+If infrastructure code was implemented without tests (e.g., Phase 2), a remediation issue MUST be created and resolved before proceeding to the next phase.
+
+---
+
 ## Project Structure
 
 ### Documentation (this feature)

--- a/specs/001-ar-furniture-previewer/tasks.md
+++ b/specs/001-ar-furniture-previewer/tasks.md
@@ -11,6 +11,19 @@
 
 ---
 
+## ⚠️ TDD Rules (MANDATORY)
+
+**All implementation tasks MUST follow Test-Driven Development:**
+
+1. **Test tasks** (marked with "Unit tests for..." or "Integration tests for...") MUST be completed FIRST
+2. **Implementation tasks** can only begin AFTER their corresponding test task is complete
+3. **PRs** must include test file commits that predate implementation commits
+4. **Coverage gate**: `yarn test --coverage` must show ≥80% for business logic
+
+**Violation of these rules will result in PR rejection.**
+
+---
+
 ## Phase 1: Setup (Shared Infrastructure)
 
 **Purpose**: Project initialization and React Native + Expo bare workflow setup
@@ -85,7 +98,20 @@
 - [X] T032a Migrate ESLint from legacy .eslintrc.js to ESLint 9 flat config in eslint.config.js (remove incompatible eslint-plugin-react-native, update package.json lint scripts)
 - [X] T032b Run `yarn typecheck` and `yarn lint` to validate all Phase 2 code passes strict TypeScript and ESLint checks
 
-**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+### TDD Remediation (BLOCKING)
+
+⚠️ **Phase 2 was implemented without TDD. The following tests MUST be written before Phase 3 begins.**
+
+- [ ] T032c [P] Write unit tests for stores: useSettingsStore.test.ts, useModelStore.test.ts, useSceneStore.test.ts, useARStore.test.ts
+- [ ] T032d [P] Write unit tests for infrastructure: FileSystemAdapter.test.ts, asyncStorageHelpers.test.ts
+- [ ] T032e [P] Write unit tests for WebView bridge: ARWebViewBridge.test.ts, messageHandlers.test.ts
+- [ ] T032f [P] Write unit tests for permissions: PermissionsAdapter.test.ts, usePermissions.test.ts
+- [ ] T032g [P] Write unit tests for components: Button.test.tsx, Card.test.tsx, Modal.test.tsx, SkeletonLoader.test.tsx
+- [ ] T032h Run `yarn test --coverage` and verify ≥80% coverage for all Phase 2 code
+
+**🚫 GATE: Phase 3 cannot begin until T032c-T032h are complete and coverage threshold is met.**
+
+**Checkpoint**: Foundation ready with test coverage - user story implementation can now begin in parallel
 
 ---
 
@@ -96,6 +122,8 @@
 **Independent Test**: Launch app → grant camera → select model from library → tap to place in AR → pinch/drag/rotate model
 
 ### Tests for User Story 1 (TDD - Write FIRST, must FAIL before implementation)
+
+⚠️ **TDD MANDATORY**: Each test task MUST be completed and committed BEFORE its corresponding implementation task.
 
 - [ ] T033 [P] [US1] Unit tests for ModelStorageService in tests/unit/services/ModelStorageService.test.ts (getAllModels, getModel, canAddModel)
 - [ ] T034 [P] [US1] Unit tests for BundledAssetsService in tests/unit/services/BundledAssetsService.test.ts (copy bundled files)


### PR DESCRIPTION
- Add TDD Enforcement section to plan.md with:
  - Red-Green-Refactor workflow description
  - Enforcement rules table (tests first, coverage gate, critical paths)
  - PR checklist for TDD compliance
  - No exemptions policy

- Add TDD Rules section to tasks.md header with:
  - Mandatory test-first requirement
  - Coverage gate (80% for business logic)
  - PR rejection warning for violations

- Add TDD Remediation section in Phase 2 (T032c-T032h):
  - Retroactive tests for stores, infrastructure, WebView bridge
  - Permissions and component tests
  - Blocking gate before Phase 3 can begin

- Add TDD MANDATORY warning to Phase 3 test section

Addresses TDD violations identified in Phase 2 implementation. Relates to: #167